### PR TITLE
Generate static binaries with musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,16 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - x86_64-apple-darwin
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: spacer-x86_64-unknown-linux-gnu.tar.gz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            name: spacer-x86_64-unknown-linux-musl.tar.gz
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: spacer-x86_64-apple-darwin.tar.gz
@@ -177,6 +181,11 @@ jobs:
       - name: Download releases from github_build
         uses: actions/download-artifact@v3
         with:
+          name: spacer-x86_64-unknown-linux-musl.tar.gz
+          path: .
+      - name: Download releases from github_build
+        uses: actions/download-artifact@v3
+        with:
           name: spacer-x86_64-apple-darwin.tar.gz
           path: .
       - name: Download releases from github_build
@@ -194,6 +203,8 @@ jobs:
           files: |
             spacer-x86_64-unknown-linux-gnu.tar.gz
             spacer-x86_64-unknown-linux-gnu.tar.gz.sha256
+            spacer-x86_64-unknown-linux-musl.tar.gz
+            spacer-x86_64-unknown-linux-musl.tar.gz.sha256
             spacer-x86_64-apple-darwin.tar.gz
             spacer-x86_64-apple-darwin.tar.gz.sha256
             spacer-x86_64-pc-windows-msvc.zip


### PR DESCRIPTION
I downloaded the latest release and got GLIBC errors on an old ubuntu box:

```
❯ spacer
spacer: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by spacer)
spacer: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by spacer)
spacer: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by spacer)
```

So I cloned the repo & built from source using musl - which worked! 🎉