### PR TITLE
Update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,10 +129,10 @@ jobs:
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             name: spacer-x86_64-unknown-linux-gnu.tar.gz
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             name: spacer-x86_64-unknown-linux-musl.tar.gz
           - target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   # Ensure that the project could be successfully compiled
   cargo_check:
     name: Check Code Compiles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -41,7 +41,7 @@ jobs:
   rustfmt:
     name: Rustfmt [Formatter]
     needs: cargo_check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -60,7 +60,7 @@ jobs:
   clippy:
     name: Clippy [Linter]
     needs: cargo_check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   cargo_audit:
     name: Cargo Audit [Security]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-latest, macOS-latest]
         rust: [stable, nightly]
 
     steps:
@@ -129,10 +129,10 @@ jobs:
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             name: spacer-x86_64-unknown-linux-gnu.tar.gz
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-22.04
             name: spacer-x86_64-unknown-linux-musl.tar.gz
           - target: x86_64-apple-darwin
             os: macOS-latest
@@ -183,7 +183,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     name: Create GitHub Release
     needs: [test, github_build, cargo_audit]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -230,7 +230,7 @@ jobs:
     needs: [test, cargo_audit]
     if: startsWith(github.ref, 'refs/tags/v')
     name: Publish Cargo Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           cd -
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -188,22 +188,22 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download releases from github_build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spacer-x86_64-unknown-linux-gnu.tar.gz
           path: .
       - name: Download releases from github_build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spacer-x86_64-unknown-linux-musl.tar.gz
           path: .
       - name: Download releases from github_build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spacer-x86_64-apple-darwin.tar.gz
           path: .
       - name: Download releases from github_build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spacer-x86_64-pc-windows-msvc.zip
           path: .


### PR DESCRIPTION
This PR updates the build workflow to
1. use `v4` of the GH artifact actions (`v3` being deprecated -- see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
2. build the Linux release artifacts using the `ubuntu-20.04` runners instead of `ubuntu-latest` so as to build against glibc 2.31 for compatibility with a much wider range of Linux distributions.

Note that the CI tasks are running on `ubuntu-22.04` for better compatibility with the `actions-rs/cargo@v1` action.

Closes #24.