### PR TITLE
Refactor synchronization and remove redundant argument check + issue #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea/

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,11 +194,6 @@ fn run(
     args: Args,
     mut test_stats: Option<&mut TestStats>,
 ) -> Result<()> {
-    if args.force_color && args.no_color {
-        eprintln!("--force-color and --no-color are mutually exclusive");
-        std::process::exit(1);
-    }
-
     if args.no_color {
         owo_colors::set_override(false);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,14 +86,8 @@ fn print_spacer(output: Arc<Mutex<impl Write + Send + 'static>>, args: &Args, la
     let (width, _) = terminal_size::terminal_size().unwrap_or((Width(80), Height(24)));
     debug!("terminal width: {:?}", width);
 
-    let mut lock_output = output.lock().expect("failed to lock output");
     let mut dashes: i32 = width.0.into();
-
-    if args.padding > 0 {
-        writeln!(lock_output, "{}", "\n".repeat(args.padding - 1))?;
-    }
-    drop(lock_output);
-
+    
     let datetime_strings = match args.timezone.clone() {
         None => {
             let now: DateTime<Local> = Local::now();
@@ -159,6 +153,10 @@ fn print_spacer(output: Arc<Mutex<impl Write + Send + 'static>>, args: &Args, la
         let start_waiting = Instant::now();
         let mut output = output.lock().expect("failed to lock output");
 
+        if padding > 0 {
+            writeln!(output, "{}", "\n".repeat(padding - 1))?;
+        }
+
         loop {
             let mut buf = buf.clone();
             let elapsed_time = start_waiting.elapsed().as_secs_f64();
@@ -205,7 +203,7 @@ fn print_spacer(output: Arc<Mutex<impl Write + Send + 'static>>, args: &Args, la
             if stop_flag.load(Ordering::Relaxed) {
                 writeln!(output, "")?;
                 if padding > 0 {
-                    writeln!(output, "\n{}", "\n".repeat(padding - 1))?;
+                    writeln!(output, "{}", "\n".repeat(padding - 1))?;
                 }
 
                 break;


### PR DESCRIPTION
- Removed unnecessary `Arc`.
- Replaced `RwLock` with `Mutex`, since multiple readers are not needed.
- Removed the explicit check for `no_color` and `force_color` flags, as this is already handled by `clap` using `group = "color-overrides"`.