### PR TITLE
Automate publishing to Homebrew

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,16 @@
+name: Publish to Homebrew
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v5
+        with:
+          token: ${{secrets.HOMEBREW_TOKEN}}
+          formula: "spacer"


### PR DESCRIPTION
Following the instructions from the [Homebrew bump formula GitHub Action](https://github.com/marketplace/actions/homebrew-bump-formula) add a new workflow to publish changes to Homebrew.